### PR TITLE
Properly handles ACTION messages

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -43,6 +43,12 @@ module IRC_Log
       @msgs = @@redis.lrange("irclog:channel:##{channel}", 0, -1)
       @msgs = @msgs.map {|msg| JSON.parse(msg) }
       @msgs = @msgs.select {|msg| d = Time.at(msg["time"].to_f) - Time.parse(@date); d >= 0 && d <= 86400 }
+      @msgs = @msgs.map {|msg|
+        if msg["msg"] =~ /^\u0001ACTION (.*)\u0001$/
+          msg["msg"].gsub!(/^\u0001ACTION (.*)\u0001$/, "<span class=\"nick\">#{msg["nick"]}</span>&nbsp;\\1")
+          msg["nick"] = "*"
+        end; msg
+      }
 
       erb :channel
     end

--- a/sass/screen.sass
+++ b/sass/screen.sass
@@ -125,6 +125,9 @@ body
       .msg
         color: $base1
         margin-left: 200px
+        .nick
+          width: auto
+          margin-left: 0px
 
 .wordwrap
   -ms-word-break: break-all


### PR DESCRIPTION
![Screen Shot 2013-01-29 at 12 17 43 AM](https://f.cloud.github.com/assets/9305/105924/400663da-69d3-11e2-88fb-404826057f65.png)

This patch enables Logbot to properly handles IRC ACTION messages. It will no longer display as ACTION [message], instead, it will be presented as most IRC clients do.

```
* [NICK] [ACTION]
```

The `\u0001` character wrapped around ACTION messages are also stripped, as they're not meant to be _displayed_ on the client.
