### PR TITLE
Fix error when the Redis is empty

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -72,14 +72,14 @@ module Comet
     get %r{/poll/(.*)/([\d\.]+)/updates.json} do |channel, time|
       date = Time.at(time.to_f).strftime("%Y-%m-%d")
       msgs = @@redis.lrange("irclog:channel:##{channel}:#{date}", -10, -1).map{|msg| ::JSON.parse(msg) }
-      if msgs[-1]["time"] > time
+      if not msgs.empty? and msgs[-1]["time"] > time
         msgs.select{|msg| msg["time"] > time }.to_json
       end
 
       EventMachine.run do
         n, timer = 0, EventMachine::PeriodicTimer.new(0.5) do
           msgs = @@redis.lrange("irclog:channel:##{channel}:#{date}", -10, -1).map{|msg| ::JSON.parse(msg) }
-          if msgs[-1]["time"] > time || n > 120
+          if not msgs.empty? and usgs[-1]["time"] > time || n > 120
             timer.cancel
             return msgs.select{|msg| msg["time"] > time }.to_json
           end


### PR DESCRIPTION
When doing long polling, the result of "redis.lrange" could be empty.
Current if condition didn't check that if it's empty or not, hence it would generate a lot of errors for a newly established site.
